### PR TITLE
[PHOENIX-8734]: throw after logging Exception

### DIFF
--- a/egov/egov-ptis/src/main/java/org/egov/ptis/client/service/CollectionApportioner.java
+++ b/egov/egov-ptis/src/main/java/org/egov/ptis/client/service/CollectionApportioner.java
@@ -151,7 +151,7 @@ public class CollectionApportioner {
 
             LOGGER.info("receiptDetails after apportioning: " + receiptDetails);
         } catch (Exception ex) {
-            LOGGER.error("Apportioning failed", ex);
+            LOGGER.error("Apportioning failed: excess payment!", ex);
             throw ex;
         }
     }

--- a/egov/egov-ptis/src/main/java/org/egov/ptis/client/service/CollectionApportioner.java
+++ b/egov/egov-ptis/src/main/java/org/egov/ptis/client/service/CollectionApportioner.java
@@ -151,7 +151,8 @@ public class CollectionApportioner {
 
             LOGGER.info("receiptDetails after apportioning: " + receiptDetails);
         } catch (Exception ex) {
-            LOGGER.error("Apportioning failed: excess payment!", ex);
+            LOGGER.error("Apportioning failed", ex);
+            throw ex;
         }
     }
 


### PR DESCRIPTION
Consuming the exception will skip the receipt apportioning but will persist and back-update wrong demand details!